### PR TITLE
Show images for recent posts

### DIFF
--- a/_plugins/extract-first-image.rb
+++ b/_plugins/extract-first-image.rb
@@ -1,0 +1,7 @@
+Jekyll::Hooks.register :posts, :post_init do |post|
+  next if post.data['image']
+  match = post.content.match(/!\[[^\]]*\]\(([^)]+)\)/)
+  if match
+    post.data['image'] = match[1]
+  end
+end

--- a/index.md
+++ b/index.md
@@ -9,11 +9,28 @@ title: Home
 
 ## 📝 Recent Post
 
-<ul>
-  {% for post in site.posts limit:5 %}
-    <li>
-      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      <small>({{ post.date | date: "%Y-%m-%d" }})</small>
-    </li>
+{% assign recent_posts = site.posts | slice: 0, 5 %}
+<div class="mb-4" id="recent-posts">
+  {% for post in recent_posts %}
+  <a href="{{ post.url | relative_url }}" class="card-wrapper d-block mb-3">
+    <div class="card post-preview flex-md-row-reverse">
+      {% if post.image %}
+        {% assign src = post.image %}
+        {% unless src contains '//' %}
+          {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
+        {% endunless %}
+        <img src="{{ src }}" w="17" h="10" alt="{{ post.title | xml_escape }}">
+      {% endif %}
+      <div class="card-body d-flex flex-column">
+        <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>
+        <div class="card-text post-content mt-0 mb-2">
+          <p>
+            {% include no-linenos.html content=post.content %}
+            {{ content | markdownify | strip_html | truncate: 200 | escape }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </a>
   {% endfor %}
-</ul>
+</div>


### PR DESCRIPTION
## Summary
- display post preview cards with excerpts and images on home page
- auto-detect the first image from post content if none specified in front matter

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_687377a84a808323a8c69adefee0be5b