### PR TITLE
Improve recent posts layout

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,3 +4,51 @@
 @import '{{ site.theme }}';
 
 /* append your custom style below */
+
+#recent-posts {
+  a.card-wrapper {
+    &:hover {
+      text-decoration: none;
+    }
+
+    .card {
+      display: flex;
+      align-items: center;
+    }
+
+    .preview-img {
+      width: 5rem;
+      height: 5rem;
+      margin-right: 1rem;
+      overflow: hidden;
+      flex-shrink: 0;
+      border-radius: $base-radius;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: $base-radius;
+      }
+    }
+
+    .card-body {
+      padding: 0;
+    }
+
+    .card-title {
+      @extend %text-clip;
+      font-size: 1.1rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .card-text {
+      margin-bottom: 0;
+
+      p {
+        @extend %text-clip;
+        margin: 0;
+      }
+    }
+  }
+}

--- a/index.md
+++ b/index.md
@@ -19,7 +19,9 @@ title: Home
         {% unless src contains '//' %}
           {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
         {% endunless %}
-        <img src="{{ src }}" w="17" h="10" alt="{{ post.title | xml_escape }}">
+        <div class="preview-img">
+          <img src="{{ src }}" alt="{{ post.title | xml_escape }}">
+        </div>
       {% endif %}
       <div class="card-body d-flex flex-column">
         <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>


### PR DESCRIPTION
## Summary
- keep recent post images in a square
- style recent posts section for a cleaner look

## Testing
- `npm test` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68737d33bc688323aaf4f4a5e3df4f02