### PR TITLE
Improve recent posts layout

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,3 +4,62 @@
 @import '{{ site.theme }}';
 
 /* append your custom style below */
+
+#recent-posts {
+  a.card-wrapper {
+    &:hover {
+      text-decoration: none;
+    }
+
+    .card {
+      display: flex;
+      align-items: center;
+    }
+
+    .preview-img {
+      width: 6rem;
+      aspect-ratio: 1;
+      margin-right: 1rem;
+      overflow: hidden;
+      flex-shrink: 0;
+      border-radius: $base-radius;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: $base-radius;
+      }
+
+      @media (min-width: 768px) {
+        width: 35%;
+        min-width: 8rem;
+      }
+    }
+
+    .card-body {
+      flex: 1;
+      padding: 0;
+    }
+
+    .card-title {
+      @extend %text-clip;
+      font-size: 1.25rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .card-text {
+      margin-bottom: 0;
+      font-size: 0.85rem;
+
+      p {
+        display: -webkit-box;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 1;
+        margin: 0;
+      }
+    }
+  }
+}

--- a/index.md
+++ b/index.md
@@ -19,7 +19,9 @@ title: Home
         {% unless src contains '//' %}
           {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
         {% endunless %}
-        <img src="{{ src }}" w="17" h="10" alt="{{ post.title | xml_escape }}">
+        <div class="preview-img">
+          <img src="{{ src }}" alt="{{ post.title | xml_escape }}">
+        </div>
       {% endif %}
       <div class="card-body d-flex flex-column">
         <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>


### PR DESCRIPTION
## Summary
- enlarge preview images to take about one-third of each card
- show only one line of excerpt with ellipsis
- tune font sizes for titles and excerpt

## Testing
- `npm test` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68737d33bc688323aaf4f4a5e3df4f02